### PR TITLE
Re-add node-example submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,7 @@
 	path = silverstripe-advanced
 	url = https://github.com/amazeeio/silverstripe-example.git
 	branch = redis_solr
+[submodule "node-example"]
+	path = node-example
+	url = https://github.com/amazeeio/node-example.git
+	branch = master


### PR DESCRIPTION
As a result of 8f18b3e4b9a1cf61b97f9ddc5cf0adb09b6b762e, there's some funniness with the submodule config for `node-example` which is breaking a project I manage which uses this repository as a test base.